### PR TITLE
added default config in the background for tolerations

### DIFF
--- a/notebook-servers/jupyter-spark/conf/pod_toleration_template.yaml
+++ b/notebook-servers/jupyter-spark/conf/pod_toleration_template.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+spec:
+  tolerations:
+    - key: "kubesoup.com/tier"
+      operator: "Equal"
+      value: "spark-dedicated"
+      effect: "NoSchedule"


### PR DESCRIPTION
Added default config to use pod templates for spark.
For more details see: https://kubesoup.atlassian.net/browse/KK-121